### PR TITLE
Colorize Output for Dark Background

### DIFF
--- a/cli/dmc.js
+++ b/cli/dmc.js
@@ -45,10 +45,10 @@ loadCommand('resources');
 // loadCommand('get');
 
 // bootstraps any necessary config items
-user.bootstrap().then(function(){
-  // preload all of the configuration files
-  return config.loadAll();
-}).then(function(){
+user.bootstrap()
+.then(config.loadAll)
+.then(config.configColors)
+.then(function(){
   // starts the program
   program.parse(process.argv);
 

--- a/lib/config-colors.js
+++ b/lib/config-colors.js
@@ -1,0 +1,16 @@
+var colors = require('colors');
+
+module.exports = function(config) {
+  colors.setTheme({
+    list: 'magenta',
+    create: 'cyan',
+    update: 'cyan',
+    destroy: 'cyan',
+    unchanged: 'grey',
+    good: 'green',
+    bad: 'red',
+    log: config.get('background') === 'dark' ? 'grey' : 'blue',
+    highlight: 'yellow'
+  });
+  colors.enabled = config.get('colorize');
+};

--- a/lib/config-schema.js
+++ b/lib/config-schema.js
@@ -32,6 +32,13 @@ var schema = [
     defaultValue: true
   },
   {
+    name: 'background',
+    type: types.enum,
+    nullable: false,
+    enumValues: ['light', 'dark'],
+    defaultValue: 'light'
+  },
+  {
     name: 'log_level',
     type: types.enum,
     nullable: true,

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@ var Promise      = require('bluebird');
 var _            = require('lodash');
 var paths        = require('./paths');
 var configSchema = require('./config-schema');
+var configColors = require('./config-colors');
 
 var globalConfig = new Config({
   isGlobal: true,
@@ -228,3 +229,5 @@ module.exports.global = function() {
 module.exports.local = function() {
   return localConfig;
 };
+
+module.exports.configColors = _.partial(configColors, module.exports);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -31,43 +31,37 @@ var error = function(text) {
 
 var list = function(text, vals) {
   if(logLevel < 1) return;
-  var li = '*';
-  if(config.get('colorize')) li = li.magenta;
+  var li = '*'.list;
   return log(li + ' ' + text);
 };
 
 var listError = function(text, vals) {
   if(logLevel < 1) return;
-  var li = '*';
-  if(config.get('colorize')) li = li.red;
+  var li = '*'.bad;
   return error(li + ' ' + text);
 };
 
 var create = function(text, vals) {
   if(logLevel < 1) return;
-  var create = '[create] ';
-  if(config.get('colorize')) create = create.cyan;
+  var create = '[create] '.create;
   return log(create + text);
 };
 
 var update = function(text, vals) {
   if(logLevel < 1) return;
-  var update = '[update] ';
-  if(config.get('colorize')) update = update.cyan;
+  var update = '[update] '.update;
   return log(update + text);
 };
 
 var destroy = function(text, vals) {
   if(logLevel < 1) return;
-  var destroy = '[delete] ';
-  if(config.get('colorize')) destroy = destroy.cyan;
+  var destroy = '[delete] '.destroy;
   return log(destroy + text);
 };
 
 var noChange = function(text, vals) {
   if(logLevel < 1) return;
-  var nochange = '[skipped] ';
-  if(config.get('colorize')) nochange = nochange.grey;
+  var nochange = '[skipped] '.unchanged;
   return log(nochange + text);
 };
 
@@ -75,56 +69,31 @@ var done = function(ok) {
   if(logLevel < 1) return;
   ok = (typeof ok !== 'undefined') ? ok : true;
 
-  if(config.get('colorize')) {
-    if(ok) {
-      log('[OK]'.green);
-    } else {
-      error('[NOT OK]'.red);
-    }
+  if(ok) {
+    log('[OK]'.good);
   } else {
-    if(ok) {
-      log('[OK]');
-    } else {
-      log('[NOT OK]');
-    }
+    log('[NOT OK]'.bad);
   }
 };
 
 var formatLog = function(text) {
-  var l = '';
-  if(config.get('colorize')) {
-    l += '[dmc] '.blue;
-  } else {
-    l += '[dmc] ';
-  }
+  var l = '[dmc] '.log;
   return l += text;
 };
 
 var formatError = function(text) {
-  var l = '';
-  if(config.get('colorize')) {
-    l += '[err] '.red;
-  } else {
-    l += '[err] ';
-  }
-  return l += text.red;
+  var l = '[err] '.bad;
+  return l += text.bad;
 };
 
 var formatSuccess = function(text) {
-  var l = '';
-  if(config.get('colorize')) {
-    l += '[dmc] '.blue;
-  } else {
-    l += '[dmc] ';
-  }
-  return l += text.green;
+  var l = '[dmc] '.log;
+  return l += text.good;
 };
 
 var highlight = function(text) {
-  text = '' + text;
-  if(config.get('colorize')) {
-    text = text.yellow;
-  } else {
+  text = ('' + text).highlight;
+  if(!config.get('colorize')) {
     text = '*' + text + '*';
   }
   return text;

--- a/test/config-colors.js
+++ b/test/config-colors.js
@@ -1,0 +1,54 @@
+var should       = require('should');
+var configColors = require('../lib/config-colors');
+var config = require('../lib/config');
+var colors = require('colors');
+
+describe('lib/config-colors', function() {
+  it('should define logging colors', function() {
+    configColors(config);
+    should.exist(colors.list);
+    should.exist(colors.create);
+    should.exist(colors.update);
+    should.exist(colors.destroy);
+    should.exist(colors.unchanged);
+    should.exist(colors.good);
+    should.exist(colors.bad);
+    should.exist(colors.log);
+    should.exist(colors.highlight);
+  });
+  describe('when colorize is enabled', function() {
+    beforeEach(function() {
+      config.global().set('colorize', true);
+    });
+
+    describe('when background is dark', function() {
+      beforeEach(function() {
+        config.global().set('background', 'dark');
+        configColors(config);
+      });
+      it('should color log messages grey', function() {
+        'test'.log.should.equal('test'.grey);
+      });
+    });
+
+    describe('when background is light', function() {
+      beforeEach(function() {
+        config.global().set('background', 'light');
+        configColors(config);
+      });
+      it('should color log messages blue', function() {
+        'test'.log.should.equal('test'.blue);
+      });
+    });
+  });
+
+  describe('when colorize is disabled', function() {
+    beforeEach(function() {
+      config.global().set('colorize', false);
+      configColors(config);
+    });
+    it('should not colorize strings', function() {
+      'test'.log.should.equal('test');
+    });
+  });
+});

--- a/test/config-schema.js
+++ b/test/config-schema.js
@@ -79,6 +79,10 @@ describe('lib/config-schema', function() {
       configSchema.getDefaultValue('colorize').should.equal(true);
     });
 
+    it('should return the default for background', function(){
+      configSchema.getDefaultValue('background').should.equal('light');
+    });
+
   });
 
   describe('#getDefaultConfig', function() {
@@ -89,6 +93,7 @@ describe('lib/config-schema', function() {
       cfg.should.have.property('api_version', 32);
       cfg.should.have.property('colorize', true);
       cfg.should.have.property('log_level', 'info');
+      cfg.should.have.property('background', 'light');
     });
 
   });


### PR DESCRIPTION
Add new config option, background, which can be set to either 'light'
(default) or 'dark'.  When colorized output is enabled, the colors used
should be visible on the configured background.

Update logging module to use theme colors.

Disable colorization globally in the colors module when colorize is
disabled.