### PR TITLE
Add Support for Metadata In Folders

### DIFF
--- a/commands/retrieve.js
+++ b/commands/retrieve.js
@@ -27,7 +27,8 @@ function getFilePaths(typeGroups, oauth, client) {
       client.meta.listMetadata({
         queries: _.map(types, function(t) {
           return {
-            type: t.name
+            type: t.name,
+            folder: t.folder
           };
         })
       }).then(function(res) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -232,27 +232,20 @@ Index.prototype.getTypesFromGlobs = function(globs) {
     globs = [globs];
   }
 
-  var newGlobs = _(globs)
-    .map(function(g){
-      var split = g.split('/');
-      while(split.length > 2) split.pop();
-      return split.join('/');
-    })
-    .uniq()
-    .value();
-
-  return _.filter(this._index.metadataObjects, function(t) {
-    var match = false;
-
-    _.each(newGlobs, function(g) {
-      if(minimatch('src/' + t.folder, g, matchOpts)) {
-        match = true;
-        return false;
+  return _(this._index.metadataObjects).map(function(t) {
+    return _.map(globs, function(g) {
+      var components = g.split('/');
+      if(minimatch('src/' + t.folder, components.slice(0, 2).join('/'), matchOpts)) {
+        return {
+          name: t.name,
+          folder: t.subFolders ? components[2] : null
+        };
       }
     });
-
-    return match;
-  });
+  })
+  .flatten()
+  .compact()
+  .value();
 };
 
 /* export init function */

--- a/test/index.js
+++ b/test/index.js
@@ -267,6 +267,20 @@ describe('lib/index.js', function() {
       _.pluck(types, 'name').should.containEql('ApexClass');
     });
 
+    it('should match reports on subfolder', function() {
+      var types = idx.getTypesFromGlobs('src/reports/My_Folder/*');
+      types.should.be.an.Array;
+      types.length.should.equal(1);
+      _.pluck(types, 'name').should.containEql('Report');
+    });
+
+    it('should include folder name when matching reports', function() {
+      var types = idx.getTypesFromGlobs('src/reports/My_Folder/*');
+      types.should.be.an.Array;
+      types.length.should.equal(1);
+      _.pluck(types, 'folder').should.containEql('My_Folder');
+    });
+
     it('should match on globstar all', function(){
       var types = idx.getTypesFromGlobs('**/*');
       types.should.be.an.Array;


### PR DESCRIPTION
Add support for retrieving metadata objects contained within folders:
documents, email templates, reports, and dashboards.