### PR TITLE
'Undefined is not a function' error in login command

### DIFF
--- a/commands/login.js
+++ b/commands/login.js
@@ -56,10 +56,6 @@ var run = module.exports.run = function(opts, cb) {
               }
             });
           });
-        })
-
-        .then(function(){
-          logger.log('login complete');
         });
 
         authServer.listen(3835, function(err){


### PR DESCRIPTION
This fixes a small typo in the `dmc login` command.