### PR TITLE
#28 Use nodirs to ensure nested directories dont make it into the met…

### DIFF
--- a/lib/get-files.js
+++ b/lib/get-files.js
@@ -24,7 +24,7 @@ module.exports = function(opts, cb) {
     var iterator = function(g, cb) {
       glob(g, {
         matchBase: true,
-        nodir: false,
+        nodir: true,
         noglobstar: false,
         nomount: true,
         ignore: opts.ignores


### PR DESCRIPTION
Just changing to to `nodir: true` will mean that directories are not included in the metadata list for those subfoldered types with metadata like document. 

Not sure if there are scenarios where an actual folder is deployed but seems unlikely as usually just packed files potentially in subfolders.

Its not convenient to need to use `src/documents/{folder1,folder2,folder3}/*` or other possible permutations.

Fixes #28 